### PR TITLE
Fixed aidl proguard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,3 +12,6 @@
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+-keepattributes LineNumberTable,SourceFile
+-renamesourcefileattribute SourceFile

--- a/framework/shizuku/consumer-proguard-rules.pro
+++ b/framework/shizuku/consumer-proguard-rules.pro
@@ -1,7 +1,9 @@
--keep class com.android.geto.framework.shizuku.** { *; }
+-keepclassmembers class com.android.geto.framework.shizuku.UserService {
+    public <init>(...);
+}
 
--keep class rikka.shizuku.** { *; }
-
-# Don't remove these rules or else you will get Security exception User does not exists.
--dontobfuscate
--dontoptimize
+# Need to keep AIDL files as it is
+-keep class android.content.pm.IPackageManager { *; }
+-keep class android.content.pm.IPackageManager$Default { *; }
+-keep class android.content.pm.IPackageManager$Stub { *; }
+-keep class android.content.pm.IPackageManager$Stub$Proxy { *; }

--- a/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
+++ b/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
@@ -163,10 +163,14 @@ internal class DefaultShizukuWrapper @Inject constructor(@ApplicationContext pri
 
     private fun grantRuntimePermission() {
         try {
+            val isRoot = Shizuku.getUid() == 0
+
+            val userId = if (isRoot) android.os.Process.myUserHandle().hashCode() else 0
+
             userService?.grantRuntimePermission(
                 context.packageName,
                 Manifest.permission.WRITE_SECURE_SETTINGS,
-                0,
+                userId,
             )
 
             _shizukuStatus.tryEmit(


### PR DESCRIPTION
_Thanks for submitting a pull request. Please include the following information._

**What I have done and why**

Previous version has a slightly larger APK size since I disabled R8 optimization as I cannot figure out why my app was crashing. Turns out that I need to exclude the generated Java class from an AIDL.

Fixes #<issue_number_goes_here>

**How I'm testing it**

_Choose at least one:_

- Unit tests
- UI tests
- Screenshot tests
- N/A _(provide justification)_

**Do tests pass?**

- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

