### PR TITLE
framework-instrumentation-tests

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -681,6 +681,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-770326884">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-754964680">
           <value>
             <AndroidTestResultsTableState>
@@ -1229,6 +1242,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="118411249">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="224651062">
           <value>
             <AndroidTestResultsTableState>
@@ -1412,6 +1438,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="549151366">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="567768532">
           <value>
             <AndroidTestResultsTableState>
@@ -1465,6 +1504,19 @@
           </value>
         </entry>
         <entry key="733040659">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="781182081">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -1699,6 +1751,19 @@
           </value>
         </entry>
         <entry key="1142187567">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1154249969">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -2324,6 +2389,19 @@
           </value>
         </entry>
         <entry key="2043910239">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="TECNO MOBILE LIMITED TECNO CH6n" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="2049474779">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -16,10 +16,10 @@
       <SelectionState runConfigName="Generate Baseline Profile for app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="AppsScreenTest">
+      <SelectionState runConfigName="PackageManagerWrapperTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="dockedSearchBar_lazyVerticalGrid_isDisplayed()">
+      <SelectionState runConfigName="queryIntentActivities_filterInstalledApplications()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/data/room/build.gradle.kts
+++ b/data/room/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
 }
 
 android {
-    defaultConfig {
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
     namespace = "com.android.geto.data.room"
 
     sourceSets {

--- a/design-system/build.gradle.kts
+++ b/design-system/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
 }
 
 android {
-    defaultConfig {
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
     namespace = "com.android.geto.designsystem"
 }
 

--- a/framework/asset-manager/build.gradle.kts
+++ b/framework/asset-manager/build.gradle.kts
@@ -18,6 +18,7 @@
 
 plugins {
     alias(libs.plugins.com.android.geto.library)
+    alias(libs.plugins.com.android.geto.libraryJacoco)
     alias(libs.plugins.com.android.geto.hilt)
 }
 
@@ -30,4 +31,9 @@ dependencies {
 
     implementation(projects.domain.common)
     implementation(projects.domain.framework)
+
+    androidTestImplementation(kotlin("test"))
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/framework/asset-manager/src/androidTest/assets/FakeAppSettingTemplates.json
+++ b/framework/asset-manager/src/androidTest/assets/FakeAppSettingTemplates.json
@@ -1,0 +1,1 @@
+"Trigger JsonSyntaxException in tests"

--- a/framework/asset-manager/src/androidTest/kotlin/com/android/geto/framework/assetmanager/AssetManagerWrapperTest.kt
+++ b/framework/asset-manager/src/androidTest/kotlin/com/android/geto/framework/assetmanager/AssetManagerWrapperTest.kt
@@ -1,0 +1,61 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.framework.assetmanager
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class AssetManagerWrapperTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var assetManagerWrapper: AndroidAssetManagerWrapper
+
+    @BeforeTest
+    fun setUp() {
+        assetManagerWrapper = AndroidAssetManagerWrapper(
+            ioDispatcher = testDispatcher,
+            context = context,
+        )
+    }
+
+    @Test
+    fun getAppSettingTemplates_shouldReturnParsedList_whenJsonIsReadSuccessfully() = runTest {
+        assertTrue(assetManagerWrapper.getAppSettingTemplates().isNotEmpty())
+    }
+
+    @Test
+    fun getAppSettingTemplates_shouldReturnEmpty_whenIOExceptionOccurs() = runTest {
+        assetManagerWrapper.appSettingTemplatesJson = ""
+
+        assertTrue(assetManagerWrapper.getAppSettingTemplates().isEmpty())
+    }
+
+    @Test
+    fun getAppSettingTemplates_shouldReturnEmpty_whenJsonSyntaxExceptionOccurs() = runTest {
+        assetManagerWrapper.appSettingTemplatesJson = "FakeAppSettingTemplates.json"
+
+        assertTrue(assetManagerWrapper.getAppSettingTemplates().isEmpty())
+    }
+}

--- a/framework/asset-manager/src/main/kotlin/com/android/geto/framework/assetmanager/AndroidAssetManagerWrapper.kt
+++ b/framework/asset-manager/src/main/kotlin/com/android/geto/framework/assetmanager/AndroidAssetManagerWrapper.kt
@@ -18,6 +18,7 @@
 package com.android.geto.framework.assetmanager
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers.IO
 import com.android.geto.domain.framework.AssetManagerWrapper
@@ -36,7 +37,8 @@ internal class AndroidAssetManagerWrapper @Inject constructor(
 ) : AssetManagerWrapper {
     private val appSettingsType = object : TypeToken<List<AppSettingTemplate>>() {}.type
 
-    private val appSettingTemplatesJson = "AppSettingTemplates.json"
+    @VisibleForTesting
+    var appSettingTemplatesJson = "AppSettingTemplates.json"
 
     override suspend fun getAppSettingTemplates(): List<AppSettingTemplate> {
         val jsonString = withContext(ioDispatcher) {

--- a/framework/asset-manager/src/main/kotlin/com/android/geto/framework/assetmanager/AndroidAssetManagerWrapper.kt
+++ b/framework/asset-manager/src/main/kotlin/com/android/geto/framework/assetmanager/AndroidAssetManagerWrapper.kt
@@ -24,6 +24,7 @@ import com.android.geto.domain.common.dispatcher.GetoDispatchers.IO
 import com.android.geto.domain.framework.AssetManagerWrapper
 import com.android.geto.domain.model.AppSettingTemplate
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -49,6 +50,10 @@ internal class AndroidAssetManagerWrapper @Inject constructor(
             }
         }
 
-        return Gson().fromJson(jsonString, appSettingsType)
+        return try {
+            Gson().fromJson(jsonString, appSettingsType) ?: emptyList()
+        } catch (e: JsonSyntaxException) {
+            emptyList()
+        }
     }
 }

--- a/framework/clipboard-manager/build.gradle.kts
+++ b/framework/clipboard-manager/build.gradle.kts
@@ -18,13 +18,26 @@
 
 plugins {
     alias(libs.plugins.com.android.geto.library)
+    alias(libs.plugins.com.android.geto.libraryJacoco)
     alias(libs.plugins.com.android.geto.hilt)
 }
 
 android {
     namespace = "com.android.geto.framework.clipboardmanager"
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
     implementation(projects.domain.framework)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
 }

--- a/framework/clipboard-manager/src/test/kotlin/com/android/geto/framework/clipboardmanager/ClipboardManagerWrapperTest.kt
+++ b/framework/clipboard-manager/src/test/kotlin/com/android/geto/framework/clipboardmanager/ClipboardManagerWrapperTest.kt
@@ -1,0 +1,54 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.framework.clipboardmanager
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class ClipboardManagerWrapperTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private lateinit var clipboardManagerWrapper: AndroidClipboardManagerWrapper
+
+    @BeforeTest
+    fun setUp() {
+        clipboardManagerWrapper = AndroidClipboardManagerWrapper(context = context)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun setPrimaryClip_onApi32() = runTest {
+        assertTrue(clipboardManagerWrapper.setPrimaryClip(label = "label", text = "text"))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun setPrimaryClip_onApi33() = runTest {
+        assertFalse(clipboardManagerWrapper.setPrimaryClip(label = "label", text = "text"))
+    }
+}

--- a/framework/package-manager/build.gradle.kts
+++ b/framework/package-manager/build.gradle.kts
@@ -29,4 +29,9 @@ android {
 dependencies {
     implementation(projects.domain.common)
     implementation(projects.domain.framework)
+
+    androidTestImplementation(kotlin("test"))
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/framework/package-manager/src/androidTest/kotlin/com/android/geto/framework/packagemanager/PackageManagerWrapperTest.kt
+++ b/framework/package-manager/src/androidTest/kotlin/com/android/geto/framework/packagemanager/PackageManagerWrapperTest.kt
@@ -1,0 +1,74 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.framework.packagemanager
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Our package is always be installed to different environment e.g CI so assume we
+ * will use that to test against. Robolectric can do test by mocking installed applications
+ * but kinda messy to deal with.
+ */
+class PackageManagerWrapperTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var packageManagerWrapper: AndroidPackageManagerWrapper
+
+    @BeforeTest
+    fun setUp() {
+        packageManagerWrapper = AndroidPackageManagerWrapper(
+            defaultDispatcher = testDispatcher,
+            ioDispatcher = testDispatcher,
+            context = context,
+        )
+    }
+
+    @Test
+    fun queryIntentActivities_filterInstalledApplications() = runTest {
+        assertTrue(
+            packageManagerWrapper.queryIntentActivities().all { getoApplicationInfo ->
+                (getoApplicationInfo.flags and ApplicationInfo.FLAG_SYSTEM) == 0
+            },
+        )
+    }
+
+    @Test
+    fun getApplicationIcon_forGeto() = runTest {
+        assertNotNull(packageManagerWrapper.getApplicationIcon(context.packageName))
+    }
+
+    @Test
+    fun getApplicationIcon_forInvalidPackageName_isNull() = runTest {
+        assertNull(packageManagerWrapper.getApplicationIcon(""))
+    }
+
+    @Test
+    fun queryIntentActivities_filterInstalledApplications_byLabel() = runTest {
+        assertTrue(packageManagerWrapper.queryIntentActivitiesByLabel(label = "Geto").isNotEmpty())
+    }
+}

--- a/framework/shortcut-manager/src/main/kotlin/com/android/geto/framework/shortcutmanager/mapper/ShortcutInfoCompat.kt
+++ b/framework/shortcut-manager/src/main/kotlin/com/android/geto/framework/shortcutmanager/mapper/ShortcutInfoCompat.kt
@@ -20,6 +20,7 @@ package com.android.geto.framework.shortcutmanager.mapper
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
@@ -50,7 +51,9 @@ internal fun GetoShortcutInfoCompat.asShortcutInfoCompat(
 
     return ShortcutInfoCompat.Builder(context, id).apply {
         icon?.let {
-            setIcon(IconCompat.createWithData(it, 0, it.size))
+            val bitmapIcon = BitmapFactory.decodeByteArray(it, 0, it.size)
+
+            setIcon(IconCompat.createWithBitmap(bitmapIcon))
         }
 
         setShortLabel(shortLabel)


### PR DESCRIPTION
_Thanks for submitting a pull request. Please include the following information._

**What I have done and why**

_Some of the framework classes contain complex logic like Package Manager filtering installed applications and this should not be left with using instrumented test for a closer approach of tests to android frameworks. Some of them uses robolectric like ClipboardManager to test against different SDK levels._

_This also fixed a stranged bug where you cannot make shortcuts due to invalid icons. Bytearray was not accepted by ShortcutInfo._

Fixes #296 #298 

**How I'm testing it**

_Choose at least one:_

- Unit tests
- UI tests
- Screenshot tests
- N/A _(provide justification)_

**Do tests pass?**

- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

