### PR TITLE
Update AppSettingTemplates.json: Hide USB Wireless Debugging

### DIFF
--- a/framework/asset-manager/src/main/assets/AppSettingTemplates.json
+++ b/framework/asset-manager/src/main/assets/AppSettingTemplates.json
@@ -15,6 +15,13 @@
   },
   {
     "settingType": "GLOBAL",
+    "label": "Hide USB Wireless Debugging",
+    "key": "adb_wifi_enabled",
+    "valueOnLaunch": "0",
+    "valueOnRevert": "1"
+  },
+  {
+    "settingType": "GLOBAL",
     "label": "Hide Accessibility Services",
     "key": "accessibility_enabled",
     "valueOnLaunch": "0",


### PR DESCRIPTION
**What I have done and why**

Added a "Hide USB Wireless Debugging" template.

Fixes #344

**How I'm testing it**

- Unit tests
- UI tests
- Screenshot tests
- N/A _(provide justification)_

I don't know what to answer here but I have tested it: `settings put global adb_wifi_enabled 0` and `settings put global adb_wifi_enabled 1` works via adb

**Do tests pass?**

- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

I don't know what to answer here
