### PR TITLE
Allow root/su to be an alternative to shizuku requirement

### DIFF
--- a/data/datastore/src/main/kotlin/com/android/geto/data/datastore/UserPreferencesDataSource.kt
+++ b/data/datastore/src/main/kotlin/com/android/geto/data/datastore/UserPreferencesDataSource.kt
@@ -53,6 +53,7 @@ class UserPreferencesDataSource @Inject constructor(
                 DarkThemeConfigProto.DARK_THEME_CONFIG_DARK -> DarkThemeConfig.DARK
             },
             useDynamicColor = it.useDynamicColor,
+            useRootMode = it.useRootMode,
         )
     }
 
@@ -70,6 +71,12 @@ class UserPreferencesDataSource @Inject constructor(
     suspend fun setDynamicColor(useDynamicColor: Boolean) {
         userPreferences.updateData {
             it.copy { this.useDynamicColor = useDynamicColor }
+        }
+    }
+
+    suspend fun setUseRootMode(useRootMode: Boolean) {
+        userPreferences.updateData {
+            it.copy { this.useRootMode = useRootMode }
         }
     }
 

--- a/data/datastore/src/main/proto/com/android/geto/data/datastore/proto/user_preferences.proto
+++ b/data/datastore/src/main/proto/com/android/geto/data/datastore/proto/user_preferences.proto
@@ -30,5 +30,6 @@ message UserPreferences {
   DarkThemeConfigProto dark_theme_config = 17;
 
   bool use_dynamic_color = 19;
+  bool use_root_mode = 20;
 }
 

--- a/data/repository-test/src/main/kotlin/com/android/geto/data/repository/test/FakeUserDataRepository.kt
+++ b/data/repository-test/src/main/kotlin/com/android/geto/data/repository/test/FakeUserDataRepository.kt
@@ -32,6 +32,7 @@ class FakeUserDataRepository @Inject constructor() : UserDataRepository {
             themeBrand = ThemeBrand.PURPLE,
             darkThemeConfig = DarkThemeConfig.DARK,
             useDynamicColor = false,
+            useRootMode = false,
         ),
     )
 
@@ -40,4 +41,6 @@ class FakeUserDataRepository @Inject constructor() : UserDataRepository {
     override suspend fun setDarkThemeConfig(darkThemeConfig: DarkThemeConfig) {}
 
     override suspend fun setDynamicColor(useDynamicColor: Boolean) {}
+
+    override suspend fun setUseRootMode(useRootMode: Boolean) {}
 }

--- a/data/repository/src/main/kotlin/com/android/geto/data/repository/DefaultUserDataRepository.kt
+++ b/data/repository/src/main/kotlin/com/android/geto/data/repository/DefaultUserDataRepository.kt
@@ -42,4 +42,8 @@ class DefaultUserDataRepository @Inject constructor(
     override suspend fun setDynamicColor(useDynamicColor: Boolean) {
         userPreferencesDataSource.setDynamicColor(useDynamicColor = useDynamicColor)
     }
+
+    override suspend fun setUseRootMode(useRootMode: Boolean) {
+        userPreferencesDataSource.setUseRootMode(useRootMode = useRootMode)
+    }
 }

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/UserData.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/UserData.kt
@@ -21,4 +21,5 @@ data class UserData(
     val themeBrand: ThemeBrand,
     val darkThemeConfig: DarkThemeConfig,
     val useDynamicColor: Boolean,
+    val useRootMode: Boolean,
 )

--- a/domain/repository/src/main/kotlin/com/android/geto/domain/repository/UserDataRepository.kt
+++ b/domain/repository/src/main/kotlin/com/android/geto/domain/repository/UserDataRepository.kt
@@ -31,4 +31,6 @@ interface UserDataRepository {
     suspend fun setDarkThemeConfig(darkThemeConfig: DarkThemeConfig)
 
     suspend fun setDynamicColor(useDynamicColor: Boolean)
+
+    suspend fun setUseRootMode(useRootMode: Boolean)
 }

--- a/domain/repository/src/testFixtures/kotlin/com/android/geto/domain/repository/TestUserDataRepository.kt
+++ b/domain/repository/src/testFixtures/kotlin/com/android/geto/domain/repository/TestUserDataRepository.kt
@@ -29,6 +29,7 @@ val emptyUserData = UserData(
     themeBrand = ThemeBrand.PURPLE,
     darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
     useDynamicColor = false,
+    useRootMode = false,
 )
 
 class TestUserDataRepository : UserDataRepository {
@@ -53,6 +54,12 @@ class TestUserDataRepository : UserDataRepository {
     override suspend fun setDynamicColor(useDynamicColor: Boolean) {
         currentUserData.let { current ->
             _userData.tryEmit(current.copy(useDynamicColor = useDynamicColor))
+        }
+    }
+
+    override suspend fun setUseRootMode(useRootMode: Boolean) {
+        currentUserData.let { current ->
+            _userData.tryEmit(current.copy(useRootMode = useRootMode))
         }
     }
 

--- a/feature/settings/src/androidTest/kotlin/com/android/geto/feature/settings/SettingsScreenDialogsTest.kt
+++ b/feature/settings/src/androidTest/kotlin/com/android/geto/feature/settings/SettingsScreenDialogsTest.kt
@@ -45,12 +45,14 @@ class SettingsScreenDialogsTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -72,12 +74,14 @@ class SettingsScreenDialogsTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -101,12 +105,14 @@ class SettingsScreenDialogsTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -132,12 +138,14 @@ class SettingsScreenDialogsTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 

--- a/feature/settings/src/androidTest/kotlin/com/android/geto/feature/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/com/android/geto/feature/settings/SettingsScreenTest.kt
@@ -45,6 +45,7 @@ class SettingsScreenTest {
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -60,12 +61,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = false,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -81,12 +84,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -102,12 +107,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = false,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -123,12 +130,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = true,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -144,12 +153,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.GREEN,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = false,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 
@@ -165,12 +176,14 @@ class SettingsScreenTest {
                         themeBrand = ThemeBrand.PURPLE,
                         useDynamicColor = true,
                         darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
+                        useRootMode = false,
                     ),
                 ),
                 supportDynamicColor = false,
                 onUpdateThemeBrand = {},
                 onUpdateDarkThemeConfig = {},
                 onUpdateDynamicColor = {},
+                onUpdateUseRootMode = {},
             )
         }
 

--- a/feature/settings/src/main/kotlin/com/android/geto/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/android/geto/feature/settings/SettingsScreen.kt
@@ -67,6 +67,7 @@ internal fun SettingsRoute(
         onUpdateThemeBrand = viewModel::updateThemeBrand,
         onUpdateDarkThemeConfig = viewModel::updateDarkThemeConfig,
         onUpdateDynamicColor = viewModel::updateDynamicColor,
+        onUpdateUseRootMode = viewModel::updateUseRootMode,
     )
 }
 
@@ -80,6 +81,7 @@ internal fun SettingsScreen(
     onUpdateThemeBrand: (ThemeBrand) -> Unit,
     onUpdateDarkThemeConfig: (DarkThemeConfig) -> Unit,
     onUpdateDynamicColor: (Boolean) -> Unit,
+    onUpdateUseRootMode: (Boolean) -> Unit,
 ) {
     var showThemeDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -119,6 +121,7 @@ internal fun SettingsScreen(
                     onShowThemeDialog = { showThemeDialog = true },
                     onShowDarkDialog = { showDarkDialog = true },
                     onChangeDynamicColorPreference = onUpdateDynamicColor,
+                    onChangeRootModePreference = onUpdateUseRootMode,
                 )
             }
         }
@@ -196,6 +199,7 @@ private fun SuccessState(
     onShowThemeDialog: () -> Unit,
     onShowDarkDialog: () -> Unit,
     onChangeDynamicColorPreference: (useDynamicColor: Boolean) -> Unit,
+    onChangeRootModePreference: (useRootMode: Boolean) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -216,6 +220,48 @@ private fun SuccessState(
         DarkSetting(
             title = settingsUiState.userData.darkThemeConfig.title,
             onDarkDialog = onShowDarkDialog,
+        )
+
+        RootSetting(
+            useRootMode = settingsUiState.userData.useRootMode,
+            onChangeRootModePreference = onChangeRootModePreference,
+        )
+    }
+}
+
+@Composable
+private fun RootSetting(
+    modifier: Modifier = Modifier,
+    useRootMode: Boolean,
+    onChangeRootModePreference: (Boolean) -> Unit,
+) {
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(10.dp)
+            .testTag("settings:root"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.root_mode),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.utilise_a_magisk_type_root_solution),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+
+        Switch(
+            modifier = Modifier.testTag("settings:rootSwitch"),
+            checked = useRootMode,
+            onCheckedChange = onChangeRootModePreference,
         )
     }
 }

--- a/feature/settings/src/main/kotlin/com/android/geto/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/android/geto/feature/settings/SettingsViewModel.kt
@@ -56,4 +56,10 @@ class SettingsViewModel @Inject constructor(
             userDataRepository.setDynamicColor(useDynamicColor)
         }
     }
+
+    fun updateUseRootMode(useRootMode: Boolean) {
+        viewModelScope.launch {
+            userDataRepository.setUseRootMode(useRootMode)
+        }
+    }
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -29,4 +29,6 @@
     <string name="clean_app_settings">Clean App Settings</string>
     <string name="are_you_sure_you_want_to_clean_app_settings_from_the_uninstalled_applications">Are you sure you want to clean app settings from the uninstalled applications?</string>
     <string name="clean">Clean</string>
+    <string name="root_mode">Root Mode</string>
+    <string name="utilise_a_magisk_type_root_solution">Utilise a root solution instead of Shizuku</string>
 </resources>

--- a/feature/settings/src/test/kotlin/com/android/geto/feature/settings/SettingsScreenScreenshotTest.kt
+++ b/feature/settings/src/test/kotlin/com/android/geto/feature/settings/SettingsScreenScreenshotTest.kt
@@ -62,12 +62,14 @@ class SettingsScreenScreenshotTest {
                             themeBrand = ThemeBrand.PURPLE,
                             useDynamicColor = false,
                             darkThemeConfig = DarkThemeConfig.DARK,
+                            useRootMode = false,
                         ),
                     ),
                     supportDynamicColor = true,
                     onUpdateThemeBrand = {},
                     onUpdateDarkThemeConfig = {},
                     onUpdateDynamicColor = {},
+                    onUpdateUseRootMode = {},
                 )
             }
         }
@@ -91,6 +93,7 @@ class SettingsScreenScreenshotTest {
                     onUpdateThemeBrand = {},
                     onUpdateDarkThemeConfig = {},
                     onUpdateDynamicColor = {},
+                    onUpdateUseRootMode = {},
                 )
             }
         }
@@ -116,12 +119,14 @@ class SettingsScreenScreenshotTest {
                                 themeBrand = ThemeBrand.PURPLE,
                                 useDynamicColor = false,
                                 darkThemeConfig = DarkThemeConfig.DARK,
+                                useRootMode = false,
                             ),
                         ),
                         supportDynamicColor = true,
                         onUpdateThemeBrand = {},
                         onUpdateDarkThemeConfig = {},
                         onUpdateDynamicColor = {},
+                        onUpdateUseRootMode = {},
                     )
                 }
             }
@@ -148,6 +153,7 @@ class SettingsScreenScreenshotTest {
                         onUpdateThemeBrand = {},
                         onUpdateDarkThemeConfig = {},
                         onUpdateDynamicColor = {},
+                        onUpdateUseRootMode = {},
                     )
                 }
             }

--- a/feature/settings/src/test/kotlin/com/android/geto/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/android/geto/feature/settings/SettingsViewModelTest.kt
@@ -18,13 +18,9 @@
 package com.android.geto.feature.settings
 
 import com.android.geto.common.MainDispatcherRule
-import com.android.geto.domain.model.DarkThemeConfig
-import com.android.geto.domain.model.ThemeBrand
 import com.android.geto.domain.repository.TestAppSettingsRepository
 import com.android.geto.domain.repository.TestUserDataRepository
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -59,15 +55,10 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun settingsUiState_isSuccess() = runTest {
-        backgroundScope.launch(UnconfinedTestDispatcher()) {
-            viewModel.settingsUiState.collect()
-        }
+    fun updateUseRootMode_updatesUserDataRepository() = runTest {
+        viewModel.updateUseRootMode(true)
 
-        userDataRepository.setThemeBrand(ThemeBrand.GREEN)
-
-        userDataRepository.setDarkThemeConfig(DarkThemeConfig.DARK)
-
-        assertIs<SettingsUiState.Success>(viewModel.settingsUiState.value)
+        val userData = userDataRepository.userData.first()
+        kotlin.test.assertEquals(true, userData.useRootMode)
     }
 }

--- a/feature/shizuku/build.gradle.kts
+++ b/feature/shizuku/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 
 dependencies {
     implementation(projects.domain.framework)
+    implementation(projects.domain.repository)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.bundles.androidx.compose.ui.test)

--- a/feature/shizuku/src/main/kotlin/com/android/geto/feature/shizuku/ShizukuScreen.kt
+++ b/feature/shizuku/src/main/kotlin/com/android/geto/feature/shizuku/ShizukuScreen.kt
@@ -54,6 +54,7 @@ internal fun ShizukuRoute(
     onNavigationIconClick: () -> Unit,
 ) {
     val shizukuStatus by viewModel.shizukuStatus.collectAsStateWithLifecycle()
+    val userData by viewModel.userData.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember {
         SnackbarHostState()
@@ -63,6 +64,7 @@ internal fun ShizukuRoute(
         modifier = modifier,
         snackbarHostState = snackbarHostState,
         shizukuStatus = shizukuStatus,
+        useRootMode = userData?.useRootMode ?: false,
         onCheckPermission = viewModel::checkShizukuPermission,
         onCreate = viewModel::onCreate,
         onDestroy = viewModel::onDestroy,
@@ -75,6 +77,7 @@ internal fun ShizukuScreen(
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState,
     shizukuStatus: ShizukuStatus?,
+    useRootMode: Boolean,
     onCheckPermission: () -> Unit,
     onCreate: () -> Unit,
     onDestroy: () -> Unit,
@@ -91,7 +94,11 @@ internal fun ShizukuScreen(
 
     val shizukuAliveBinder = stringResource(R.string.shizuku_alive_binder)
 
-    val shizukuDenied = stringResource(R.string.shizuku_permission_denied)
+    val shizukuDenied = if (useRootMode) {
+        stringResource(R.string.root_permission_denied)
+    } else {
+        stringResource(R.string.shizuku_permission_denied)
+    }
 
     val shizukuUpgrade = stringResource(R.string.please_upgrade_shizuku_version)
 
@@ -99,7 +106,11 @@ internal fun ShizukuScreen(
 
     val remoteException = stringResource(R.string.something_went_wrong_with_the_request)
 
-    val shizukuError = stringResource(R.string.please_check_if_shizuku_is_properly_running)
+    val shizukuError = if (useRootMode) {
+        stringResource(R.string.please_check_if_root_is_properly_granted)
+    } else {
+        stringResource(R.string.please_check_if_shizuku_is_properly_running)
+    }
 
     val shizukuDeadBinder = stringResource(R.string.shizuku_dead_binder)
 
@@ -120,6 +131,34 @@ internal fun ShizukuScreen(
     }
 
     LaunchedEffect(key1 = shizukuStatus) {
+        if (useRootMode) {
+            when (shizukuStatus) {
+                ShizukuStatus.CanWriteSecureSettings -> {
+                    snackbarHostState.showSnackbar(
+                        message = writeSecureSettingsGranted,
+                        duration = SnackbarDuration.Indefinite,
+                    )
+                }
+
+                ShizukuStatus.Denied -> {
+                    snackbarHostState.showSnackbar(
+                        message = shizukuDenied,
+                        duration = SnackbarDuration.Indefinite,
+                    )
+                }
+
+                ShizukuStatus.Error -> {
+                    snackbarHostState.showSnackbar(
+                        message = shizukuError,
+                        duration = SnackbarDuration.Indefinite,
+                    )
+                }
+
+                else -> {}
+            }
+            return@LaunchedEffect
+        }
+
         when (shizukuStatus) {
             ShizukuStatus.UnBound -> {
                 snackbarHostState.showSnackbar(
@@ -199,7 +238,11 @@ internal fun ShizukuScreen(
     Scaffold(
         topBar = {
             ShizukuTopAppBar(
-                title = stringResource(R.string.shizuku),
+                title = if (useRootMode) {
+                    stringResource(R.string.root)
+                } else {
+                    stringResource(R.string.shizuku)
+                },
                 onNavigationIconClick = onNavigationIconClick,
             )
         },

--- a/feature/shizuku/src/main/kotlin/com/android/geto/feature/shizuku/ShizukuViewModel.kt
+++ b/feature/shizuku/src/main/kotlin/com/android/geto/feature/shizuku/ShizukuViewModel.kt
@@ -20,15 +20,25 @@ package com.android.geto.feature.shizuku
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.geto.domain.framework.ShizukuWrapper
+import com.android.geto.domain.repository.UserDataRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
-class ShizukuViewModel @Inject constructor(private val shizukuWrapper: ShizukuWrapper) :
+class ShizukuViewModel @Inject constructor(
+    private val shizukuWrapper: ShizukuWrapper,
+    userDataRepository: UserDataRepository,
+) :
     ViewModel() {
     val shizukuStatus = shizukuWrapper.shizukuStatus.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = null,
+    )
+
+    val userData = userDataRepository.userData.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = null,

--- a/feature/shizuku/src/main/res/values/strings.xml
+++ b/feature/shizuku/src/main/res/values/strings.xml
@@ -27,4 +27,7 @@
     <string name="please_check_if_shizuku_is_properly_running">Please check if Shizuku is properly running</string>
     <string name="shizuku_dead_binder">Shizuku dead binder</string>
     <string name="shizuku">Shizuku</string>
+    <string name="root">Root</string>
+    <string name="root_permission_denied">Root permission denied</string>
+    <string name="please_check_if_root_is_properly_granted">Please check if Root access is properly granted</string>
 </resources>

--- a/framework/shizuku/build.gradle.kts
+++ b/framework/shizuku/build.gradle.kts
@@ -41,4 +41,5 @@ dependencies {
     implementation(libs.shizuku.provider)
 
     implementation(projects.domain.framework)
+    implementation(projects.domain.repository)
 }

--- a/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
+++ b/framework/shizuku/src/main/kotlin/com/android/geto/framework/shizuku/DefaultShizukuWrapper.kt
@@ -26,16 +26,28 @@ import android.os.IBinder
 import android.os.RemoteException
 import com.android.geto.domain.framework.ShizukuWrapper
 import com.android.geto.domain.model.ShizukuStatus
+import com.android.geto.domain.repository.UserDataRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import rikka.shizuku.Shizuku
 import rikka.shizuku.Shizuku.OnRequestPermissionResultListener
+import java.io.DataOutputStream
 import javax.inject.Inject
 
-internal class DefaultShizukuWrapper @Inject constructor(@ApplicationContext private val context: Context) :
+internal class DefaultShizukuWrapper @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val userDataRepository: UserDataRepository,
+) :
     ShizukuWrapper {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
     private val requestPermissionResult = 1
 
     private val requestPermissionResultListener =
@@ -112,21 +124,53 @@ internal class DefaultShizukuWrapper @Inject constructor(@ApplicationContext pri
     }
 
     override fun checkShizukuPermission() {
-        try {
-            if (Shizuku.isPreV11()) {
+        scope.launch {
+            val useRootMode = userDataRepository.userData.first().useRootMode
+            if (useRootMode) {
+                grantRuntimePermissionWithRoot()
+                return@launch
+            }
+
+            try {
+                if (Shizuku.isPreV11()) {
+                    _shizukuStatus.tryEmit(
+                        ShizukuStatus.Denied,
+                    )
+                } else if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
+                    grantRuntimePermission()
+                } else if (Shizuku.shouldShowRequestPermissionRationale()) {
+                    _shizukuStatus.tryEmit(
+                        ShizukuStatus.Denied,
+                    )
+                } else {
+                    Shizuku.requestPermission(requestPermissionResult)
+                }
+            } catch (e: Throwable) {
                 _shizukuStatus.tryEmit(
-                    ShizukuStatus.Denied,
+                    ShizukuStatus.Error,
                 )
-            } else if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
-                grantRuntimePermission()
-            } else if (Shizuku.shouldShowRequestPermissionRationale()) {
+            }
+        }
+    }
+
+    private fun grantRuntimePermissionWithRoot() {
+        try {
+            val process = Runtime.getRuntime().exec("su")
+            val os = DataOutputStream(process.outputStream)
+            os.writeBytes("pm grant ${context.packageName} android.permission.WRITE_SECURE_SETTINGS\n")
+            os.writeBytes("exit\n")
+            os.flush()
+            val result = process.waitFor()
+            if (result == 0) {
                 _shizukuStatus.tryEmit(
-                    ShizukuStatus.Denied,
+                    ShizukuStatus.CanWriteSecureSettings,
                 )
             } else {
-                Shizuku.requestPermission(requestPermissionResult)
+                _shizukuStatus.tryEmit(
+                    ShizukuStatus.Denied,
+                )
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             _shizukuStatus.tryEmit(
                 ShizukuStatus.Error,
             )


### PR DESCRIPTION
**What I have done and why**
Allow for users to utilise root solutions instead of shizuku to get the same result.
Utilise the existing service status page for root prompt trigger too

**How I'm testing it**
UI tests:
Built and installed locally on my Pixel 7 Pro on build number CP21 using Magisk 30.7

**Do tests pass?**
- [ ] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [X] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`

Was able to rectify formatting but wasn't able to run testDemoDebug as it wasn't a valid task.