### PR TITLE
fix(framework): handle zero dimension drawable to Bitmap crash

### DIFF
--- a/framework/package-manager/src/main/kotlin/com/android/geto/framework/packagemanager/AndroidPackageManagerWrapper.kt
+++ b/framework/package-manager/src/main/kotlin/com/android/geto/framework/packagemanager/AndroidPackageManagerWrapper.kt
@@ -111,7 +111,16 @@ class AndroidPackageManagerWrapper @Inject constructor(
         val stream = ByteArrayOutputStream()
 
         withContext(ioDispatcher) {
-            toBitmap().compress(Bitmap.CompressFormat.PNG, 30, stream)
+            try {
+                val bitmap = if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+                    toBitmap()
+                } else {
+                    toBitmap(width = 100, height = 100)
+                }
+                bitmap.compress(Bitmap.CompressFormat.PNG, 30, stream)
+            } catch (e: Exception) {
+                // Prevent zero-dimension or un-renderable drawables from fatally crashing the app loader.
+            }
         }
 
         return stream.toByteArray()


### PR DESCRIPTION
Added a fallback bounds check and try/catch block around the native `Drawable.toBitmap()` invocation to prevent an `IllegalArgumentException` from crashing the process when fetching stubs or invalid application icons.

**What I have done and why**

When parsing system applications or stub packages on device, Android frequently returns `Drawable` icons with missing or `0` intrinsic dimensions. The native `toBitmap()` call attempts to allocate a dimension matrix of `<= 0`, triggering a fatal `IllegalArgumentException` internally at `Bitmap.createBitmap()`. This fatally crashes the entire enumeration process natively.

To permanently fix this, I wrapped the `toBitmap()` conversion structure inside an explicit bounds check. If an icon lacks natural geometry, the logic enforces a safe fallback constraint (`100x100`) and quietly handles trailing parsing exceptions to maintain absolute iteration stability for the Package Manager.

**How I'm testing it**

- N/A _(Tested explicitly on physical hardware ADB logs; inherently intercepts and physically prevents the runtime `Bitmap` allocation crash)_

**Do tests pass?**

- [x] Run local tests on `DemoDebug` variant: `./gradlew testDemoDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
