### PR TITLE
feat: add update pin shortcut functionality and improve dialogs

### DIFF
--- a/.idea/AICommit.xml
+++ b/.idea/AICommit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.github.blarc.ai.commits.intellij.plugin.settings.ProjectSettings">
+    <option name="splitButtonActionSelectedLLMClientId" value="9c87f8f5-20d6-48f1-9f90-86b4565321c7" />
+  </component>
+</project>

--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,157 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/AddAppSettingResult.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/AddAppSettingResult.kt
@@ -18,6 +18,6 @@
 package com.android.geto.domain.model
 
 enum class AddAppSettingResult {
-    SUCCESS,
-    FAILED,
+    Success,
+    Failed,
 }

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/GetPinShortcutResult.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/GetPinShortcutResult.kt
@@ -1,0 +1,27 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.domain.model
+
+sealed interface GetPinShortcutResult {
+    data object UnsupportedLauncher : GetPinShortcutResult
+
+    data object RequestPinShortcut : GetPinShortcutResult
+
+    data class UpdatePinShortcut(val getoShortcutInfoCompat: GetoShortcutInfoCompat) :
+        GetPinShortcutResult
+}

--- a/domain/model/src/main/kotlin/com/android/geto/domain/model/UpdatePinShortcutResult.kt
+++ b/domain/model/src/main/kotlin/com/android/geto/domain/model/UpdatePinShortcutResult.kt
@@ -17,7 +17,9 @@
  */
 package com.android.geto.domain.model
 
-enum class RequestPinShortcutResult {
+enum class UpdatePinShortcutResult {
     UnsupportedLauncher,
-    SupportedLauncher,
+    UpdateSuccess,
+    UpdateFailure,
+    UpdateImmutableShortcuts,
 }

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/AddAppSettingUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/AddAppSettingUseCase.kt
@@ -20,8 +20,6 @@ package com.android.geto.domain.usecase
 import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers.Default
 import com.android.geto.domain.model.AddAppSettingResult
-import com.android.geto.domain.model.AddAppSettingResult.FAILED
-import com.android.geto.domain.model.AddAppSettingResult.SUCCESS
 import com.android.geto.domain.model.AppSetting
 import com.android.geto.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -40,9 +38,9 @@ class AddAppSettingUseCase @Inject constructor(
         if (appSetting.key !in keys) {
             appSettingsRepository.upsertAppSetting(appSetting = appSetting)
 
-            SUCCESS
+            AddAppSettingResult.Success
         } else {
-            FAILED
+            AddAppSettingResult.Failed
         }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplyAppSettingsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplyAppSettingsUseCase.kt
@@ -46,11 +46,11 @@ class ApplyAppSettingsUseCase @Inject constructor(
         if (appSettings.all { !it.enabled }) return@withContext DisabledAppSettings
 
         try {
-            if (appSettings.all { appSetting ->
+            if (appSettings.all {
                     secureSettingsWrapper.canWriteSecureSettings(
-                        settingType = appSetting.settingType,
-                        key = appSetting.key,
-                        value = appSetting.valueOnLaunch,
+                        settingType = it.settingType,
+                        key = it.key,
+                        value = it.valueOnLaunch,
                     )
                 }
             ) {

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplyAppSettingsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/ApplyAppSettingsUseCase.kt
@@ -21,12 +21,6 @@ import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers.Default
 import com.android.geto.domain.framework.SecureSettingsWrapper
 import com.android.geto.domain.model.AppSettingsResult
-import com.android.geto.domain.model.AppSettingsResult.DisabledAppSettings
-import com.android.geto.domain.model.AppSettingsResult.EmptyAppSettings
-import com.android.geto.domain.model.AppSettingsResult.Failure
-import com.android.geto.domain.model.AppSettingsResult.InvalidValues
-import com.android.geto.domain.model.AppSettingsResult.NoPermission
-import com.android.geto.domain.model.AppSettingsResult.Success
 import com.android.geto.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -41,9 +35,9 @@ class ApplyAppSettingsUseCase @Inject constructor(
         val appSettings =
             appSettingsRepository.getAppSettingsByComponentName(componentName = componentName)
 
-        if (appSettings.isEmpty()) return@withContext EmptyAppSettings
+        if (appSettings.isEmpty()) return@withContext AppSettingsResult.EmptyAppSettings
 
-        if (appSettings.all { !it.enabled }) return@withContext DisabledAppSettings
+        if (appSettings.all { !it.enabled }) return@withContext AppSettingsResult.DisabledAppSettings
 
         try {
             if (appSettings.all {
@@ -54,14 +48,14 @@ class ApplyAppSettingsUseCase @Inject constructor(
                     )
                 }
             ) {
-                Success
+                AppSettingsResult.Success
             } else {
-                Failure
+                AppSettingsResult.Failure
             }
         } catch (_: SecurityException) {
-            NoPermission
+            AppSettingsResult.NoPermission
         } catch (_: IllegalArgumentException) {
-            InvalidValues
+            AppSettingsResult.InvalidValues
         }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/GetPinShortcutUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/GetPinShortcutUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.android.geto.domain.usecase
+
+import com.android.geto.domain.common.dispatcher.Dispatcher
+import com.android.geto.domain.common.dispatcher.GetoDispatchers.Default
+import com.android.geto.domain.framework.ShortcutManagerCompatWrapper
+import com.android.geto.domain.model.GetPinShortcutResult
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetPinShortcutUseCase @Inject constructor(
+    @param:Dispatcher(Default) private val defaultDispatcher: CoroutineDispatcher,
+    private val shortcutManagerCompatWrapper: ShortcutManagerCompatWrapper,
+) {
+    suspend operator fun invoke(id: String): GetPinShortcutResult {
+        if (!shortcutManagerCompatWrapper.isRequestPinShortcutSupported()) {
+            return GetPinShortcutResult.UnsupportedLauncher
+        }
+
+        return withContext(defaultDispatcher) {
+            val getoShortcutInfoCompat = shortcutManagerCompatWrapper.getShortcuts().find { it.id == id }
+
+            if (getoShortcutInfoCompat != null) {
+                GetPinShortcutResult.UpdatePinShortcut(getoShortcutInfoCompat = getoShortcutInfoCompat)
+            } else {
+                GetPinShortcutResult.RequestPinShortcut
+            }
+        }
+    }
+}

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RequestPinShortcutUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RequestPinShortcutUseCase.kt
@@ -46,9 +46,9 @@ class RequestPinShortcutUseCase @Inject constructor(
         }
 
         return withContext(defaultDispatcher) {
-            val pinnedShortcut = shortcutManagerCompatWrapper.getShortcuts().find { it.id == id }
+            val getoShortcutInfoCompat = shortcutManagerCompatWrapper.getShortcuts().find { it.id == id }
 
-            if (pinnedShortcut != null) {
+            if (getoShortcutInfoCompat != null) {
                 updateShortcuts(
                     componentName = componentName,
                     icon = icon,

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertAppSettingsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertAppSettingsUseCase.kt
@@ -21,12 +21,6 @@ import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers.Default
 import com.android.geto.domain.framework.SecureSettingsWrapper
 import com.android.geto.domain.model.AppSettingsResult
-import com.android.geto.domain.model.AppSettingsResult.DisabledAppSettings
-import com.android.geto.domain.model.AppSettingsResult.EmptyAppSettings
-import com.android.geto.domain.model.AppSettingsResult.Failure
-import com.android.geto.domain.model.AppSettingsResult.InvalidValues
-import com.android.geto.domain.model.AppSettingsResult.NoPermission
-import com.android.geto.domain.model.AppSettingsResult.Success
 import com.android.geto.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -42,9 +36,9 @@ class RevertAppSettingsUseCase @Inject constructor(
             val appSettings =
                 appSettingsRepository.getAppSettingsByComponentName(componentName = componentName)
 
-            if (appSettings.isEmpty()) return@withContext EmptyAppSettings
+            if (appSettings.isEmpty()) return@withContext AppSettingsResult.EmptyAppSettings
 
-            if (appSettings.all { !it.enabled }) return@withContext DisabledAppSettings
+            if (appSettings.all { !it.enabled }) return@withContext AppSettingsResult.DisabledAppSettings
 
             try {
                 if (appSettings.all {
@@ -55,14 +49,14 @@ class RevertAppSettingsUseCase @Inject constructor(
                         )
                     }
                 ) {
-                    Success
+                    AppSettingsResult.Success
                 } else {
-                    Failure
+                    AppSettingsResult.Failure
                 }
             } catch (_: SecurityException) {
-                NoPermission
+                AppSettingsResult.NoPermission
             } catch (_: IllegalArgumentException) {
-                InvalidValues
+                AppSettingsResult.InvalidValues
             }
         }
 }

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertAppSettingsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/RevertAppSettingsUseCase.kt
@@ -47,11 +47,11 @@ class RevertAppSettingsUseCase @Inject constructor(
             if (appSettings.all { !it.enabled }) return@withContext DisabledAppSettings
 
             try {
-                if (appSettings.all { appSetting ->
+                if (appSettings.all {
                         secureSettingsWrapper.canWriteSecureSettings(
-                            settingType = appSetting.settingType,
-                            key = appSetting.key,
-                            value = appSetting.valueOnRevert,
+                            settingType = it.settingType,
+                            key = it.key,
+                            value = it.valueOnRevert,
                         )
                     }
                 ) {

--- a/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/UpdatePinShortcutUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/android/geto/domain/usecase/UpdatePinShortcutUseCase.kt
@@ -20,12 +20,12 @@ package com.android.geto.domain.usecase
 import com.android.geto.domain.common.dispatcher.Dispatcher
 import com.android.geto.domain.common.dispatcher.GetoDispatchers.Default
 import com.android.geto.domain.framework.ShortcutManagerCompatWrapper
-import com.android.geto.domain.model.RequestPinShortcutResult
+import com.android.geto.domain.model.UpdatePinShortcutResult
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class RequestPinShortcutUseCase @Inject constructor(
+class UpdatePinShortcutUseCase @Inject constructor(
     @param:Dispatcher(Default) private val defaultDispatcher: CoroutineDispatcher,
     private val shortcutManagerCompatWrapper: ShortcutManagerCompatWrapper,
 ) {
@@ -35,23 +35,34 @@ class RequestPinShortcutUseCase @Inject constructor(
         id: String,
         shortLabel: String,
         longLabel: String,
-    ): RequestPinShortcutResult {
+    ): UpdatePinShortcutResult? {
         if (!shortcutManagerCompatWrapper.isRequestPinShortcutSupported()) {
-            return RequestPinShortcutResult.UnsupportedLauncher
+            return UpdatePinShortcutResult.UnsupportedLauncher
         }
 
         return withContext(defaultDispatcher) {
-            if (shortcutManagerCompatWrapper.requestPinShortcut(
-                    componentName = componentName,
-                    icon = icon,
-                    id = id,
-                    shortLabel = shortLabel,
-                    longLabel = longLabel,
-                )
-            ) {
-                RequestPinShortcutResult.SupportedLauncher
+            val getoShortcutInfoCompat =
+                shortcutManagerCompatWrapper.getShortcuts().find { it.id == id }
+
+            if (getoShortcutInfoCompat != null) {
+                try {
+                    if (shortcutManagerCompatWrapper.updateShortcuts(
+                            componentName = componentName,
+                            icon = icon,
+                            id = id,
+                            shortLabel = shortLabel,
+                            longLabel = longLabel,
+                        )
+                    ) {
+                        UpdatePinShortcutResult.UpdateSuccess
+                    } else {
+                        UpdatePinShortcutResult.UpdateFailure
+                    }
+                } catch (_: IllegalArgumentException) {
+                    UpdatePinShortcutResult.UpdateImmutableShortcuts
+                }
             } else {
-                RequestPinShortcutResult.UnsupportedLauncher
+                null
             }
         }
     }

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsScreen.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -83,6 +82,7 @@ import com.android.geto.domain.model.AppSettingsResult.Failure
 import com.android.geto.domain.model.AppSettingsResult.InvalidValues
 import com.android.geto.domain.model.AppSettingsResult.NoPermission
 import com.android.geto.domain.model.AppSettingsResult.Success
+import com.android.geto.domain.model.GetPinShortcutResult
 import com.android.geto.domain.model.RequestPinShortcutResult
 import com.android.geto.domain.model.RequestPinShortcutResult.SupportedLauncher
 import com.android.geto.domain.model.RequestPinShortcutResult.UnsupportedLauncher
@@ -92,8 +92,9 @@ import com.android.geto.domain.model.RequestPinShortcutResult.UpdateSuccess
 import com.android.geto.domain.model.SecureSetting
 import com.android.geto.domain.model.SettingType
 import com.android.geto.feature.appsettings.dialog.AppSettingDialog
-import com.android.geto.feature.appsettings.dialog.ShortcutDialog
+import com.android.geto.feature.appsettings.dialog.RequestPinShortcutDialog
 import com.android.geto.feature.appsettings.dialog.TemplateDialog
+import com.android.geto.feature.appsettings.dialog.UpdatePinShortcutDialog
 import com.android.geto.feature.appsettings.dialog.WriteSecureSettingsDialog
 import com.android.geto.feature.appsettings.navigation.AppSettingsRouteData
 import com.android.geto.framework.notificationmanager.AndroidNotificationManagerWrapper
@@ -127,15 +128,12 @@ internal fun AppSettingsRoute(
 
     val appSettingTemplates by viewModel.appSettingTemplates.collectAsStateWithLifecycle()
 
-    val snackbarHostState = remember {
-        SnackbarHostState()
-    }
+    val getPinShortcutResult by viewModel.getPinShortcutResult.collectAsStateWithLifecycle()
 
     AppSettingsScreen(
         modifier = modifier,
         appSettingsRouteData = appSettingsRouteData,
         appSettingsUiState = appSettingsUiState,
-        snackbarHostState = snackbarHostState,
         activityIcon = activityIcon,
         secureSettings = secureSettings,
         addAppSettingResult = addAppSettingResult,
@@ -155,6 +153,10 @@ internal fun AppSettingsRoute(
         onResetRevertAppSettingsResult = viewModel::resetRevertAppSettingsResult,
         onResetAddAppSettingResult = viewModel::resetAddAppSettingResult,
         onNavigationIconClick = onNavigationIconClick,
+        getPinShortcutResult = getPinShortcutResult,
+        onGetPinShortcut = viewModel::getPinShorcut,
+        onResetGetPinShortcutResult = viewModel::resetGetPinShortcutResult,
+        onUpdatePinShortcut = viewModel::updatePinShorcut,
     )
 }
 
@@ -164,7 +166,6 @@ internal fun AppSettingsScreen(
     modifier: Modifier = Modifier,
     appSettingsRouteData: AppSettingsRouteData,
     appSettingsUiState: AppSettingsUiState,
-    snackbarHostState: SnackbarHostState,
     activityIcon: ByteArray?,
     secureSettings: List<SecureSetting>,
     addAppSettingResult: AddAppSettingResult?,
@@ -172,6 +173,7 @@ internal fun AppSettingsScreen(
     revertAppSettingsResult: AppSettingsResult?,
     requestPinShortcutResult: RequestPinShortcutResult?,
     appSettingTemplates: List<AppSettingTemplate>,
+    getPinShortcutResult: GetPinShortcutResult?,
     onApplyAppSettings: () -> Unit,
     onRevertAppSettings: () -> Unit,
     onCheckAppSetting: (appSetting: AppSetting) -> Unit,
@@ -188,14 +190,21 @@ internal fun AppSettingsScreen(
     onResetRevertAppSettingsResult: () -> Unit,
     onResetAddAppSettingResult: () -> Unit,
     onNavigationIconClick: () -> Unit,
+    onGetPinShortcut: () -> Unit,
+    onResetGetPinShortcutResult: () -> Unit,
+    onUpdatePinShortcut: (
+        icon: ByteArray?,
+        shortLabel: String,
+        longLabel: String,
+    ) -> Unit,
 ) {
     var showAppSettingDialog by remember { mutableStateOf(false) }
-
-    var showShortcutDialog by remember { mutableStateOf(false) }
 
     var showTemplateDialog by remember { mutableStateOf(false) }
 
     var showWriteSecureSettingsDialog by remember { mutableStateOf(false) }
+
+    val snackbarHostState = remember { SnackbarHostState() }
 
     AppSettingsLaunchedEffects(
         appSettingsRouteData = appSettingsRouteData,
@@ -205,6 +214,7 @@ internal fun AppSettingsScreen(
         applyAppSettingsResult = applyAppSettingsResult,
         revertAppSettingsResult = revertAppSettingsResult,
         requestPinShortcutResult = requestPinShortcutResult,
+        getPinShortcutResult = getPinShortcutResult,
         onResetApplyAppSettingsResult = onResetApplyAppSettingsResult,
         onResetRevertAppSettingsResult = onResetRevertAppSettingsResult,
         onResetRequestPinShortcutResult = onResetRequestPinShortcutResult,
@@ -212,32 +222,6 @@ internal fun AppSettingsScreen(
         onShowWriteSecureSettingsDialog = {
             showWriteSecureSettingsDialog = true
         },
-    )
-
-    AppSettingsDialogs(
-        appSettingTemplates = appSettingTemplates,
-        componentName = appSettingsRouteData.componentName,
-        icon = activityIcon,
-        secureSettings = secureSettings,
-        showAppSettingDialog = showAppSettingDialog,
-        showShortcutDialog = showShortcutDialog,
-        showTemplateDialog = showTemplateDialog,
-        showWriteSecureSettingsDialog = showWriteSecureSettingsDialog,
-        onAddAppSetting = onAddAppSetting,
-        onDismissAppSettingDialog = {
-            showAppSettingDialog = false
-        },
-        onDismissShortcutDialog = {
-            showShortcutDialog = false
-        },
-        onDismissTemplateDialog = {
-            showTemplateDialog = false
-        },
-        onDismissWriteSecureSettingsDialog = {
-            showWriteSecureSettingsDialog = false
-        },
-        onGetSecureSettingsByName = onGetSecureSettingsByName,
-        onRequestPinShortcut = onRequestPinShortcut,
     )
 
     Scaffold(
@@ -253,9 +237,7 @@ internal fun AppSettingsScreen(
                 onSettingsIconClick = {
                     showAppSettingDialog = true
                 },
-                onShortcutIconClick = {
-                    showShortcutDialog = true
-                },
+                onShortcutIconClick = onGetPinShortcut,
                 onSettingsSuggestIconClick = {
                     showTemplateDialog = true
                 },
@@ -268,9 +250,8 @@ internal fun AppSettingsScreen(
     ) { innerPadding ->
         Box(
             modifier = modifier
-                .padding(innerPadding)
                 .fillMaxSize()
-                .consumeWindowInsets(innerPadding),
+                .padding(innerPadding),
         ) {
             when (appSettingsUiState) {
                 AppSettingsUiState.Loading -> {
@@ -294,6 +275,58 @@ internal fun AppSettingsScreen(
             }
         }
     }
+
+    if (showAppSettingDialog) {
+        AppSettingDialog(
+            componentName = appSettingsRouteData.componentName,
+            secureSettings = secureSettings,
+            onAddAppSetting = onAddAppSetting,
+            onDismissRequest = {
+                showAppSettingDialog = false
+            },
+            onGetSecureSettingsByName = onGetSecureSettingsByName,
+        )
+    }
+
+    if (showTemplateDialog) {
+        TemplateDialog(
+            appSettingTemplates = appSettingTemplates,
+            componentName = appSettingsRouteData.componentName,
+            onAddAppSetting = onAddAppSetting,
+            onDismissRequest = {
+                showTemplateDialog = false
+            },
+        )
+    }
+
+    if (showWriteSecureSettingsDialog) {
+        WriteSecureSettingsDialog(
+            onDismissRequest = {
+                showWriteSecureSettingsDialog = false
+            },
+        )
+    }
+
+    when (getPinShortcutResult) {
+        GetPinShortcutResult.RequestPinShortcut -> {
+            RequestPinShortcutDialog(
+                icon = activityIcon,
+                onDismissRequest = onResetGetPinShortcutResult,
+                onRequestPinShortcut = onRequestPinShortcut,
+            )
+        }
+
+        is GetPinShortcutResult.UpdatePinShortcut -> {
+            UpdatePinShortcutDialog(
+                icon = activityIcon,
+                getoShortcutInfoCompat = getPinShortcutResult.getoShortcutInfoCompat,
+                onDismissRequest = onResetGetPinShortcutResult,
+                onUpdatePinShortcut = onUpdatePinShortcut,
+            )
+        }
+
+        GetPinShortcutResult.UnsupportedLauncher, null -> Unit
+    }
 }
 
 @OptIn(FlowPreview::class)
@@ -306,6 +339,7 @@ private fun AppSettingsLaunchedEffects(
     applyAppSettingsResult: AppSettingsResult?,
     revertAppSettingsResult: AppSettingsResult?,
     requestPinShortcutResult: RequestPinShortcutResult?,
+    getPinShortcutResult: GetPinShortcutResult?,
     onResetApplyAppSettingsResult: () -> Unit,
     onResetRevertAppSettingsResult: () -> Unit,
     onResetRequestPinShortcutResult: () -> Unit,
@@ -484,58 +518,13 @@ private fun AppSettingsLaunchedEffects(
 
         onResetAddAppSettingResult()
     }
-}
 
-@Composable
-private fun AppSettingsDialogs(
-    appSettingTemplates: List<AppSettingTemplate>,
-    componentName: String,
-    icon: ByteArray?,
-    secureSettings: List<SecureSetting>,
-    showAppSettingDialog: Boolean,
-    showShortcutDialog: Boolean,
-    showTemplateDialog: Boolean,
-    showWriteSecureSettingsDialog: Boolean,
-    onAddAppSetting: (AppSetting) -> Unit,
-    onDismissAppSettingDialog: () -> Unit,
-    onDismissShortcutDialog: () -> Unit,
-    onDismissTemplateDialog: () -> Unit,
-    onDismissWriteSecureSettingsDialog: () -> Unit,
-    onGetSecureSettingsByName: (
-        settingType: SettingType,
-        text: String,
-    ) -> Unit,
-    onRequestPinShortcut: (ByteArray?, String, String) -> Unit,
-) {
-    if (showAppSettingDialog) {
-        AppSettingDialog(
-            componentName = componentName,
-            secureSettings = secureSettings,
-            onAddAppSetting = onAddAppSetting,
-            onDismissRequest = onDismissAppSettingDialog,
-            onGetSecureSettingsByName = onGetSecureSettingsByName,
-        )
-    }
-
-    if (showShortcutDialog) {
-        ShortcutDialog(
-            icon = icon,
-            onDismissRequest = onDismissShortcutDialog,
-            onRequestPinShortcut = onRequestPinShortcut,
-        )
-    }
-
-    if (showTemplateDialog) {
-        TemplateDialog(
-            appSettingTemplates = appSettingTemplates,
-            componentName = componentName,
-            onAddAppSetting = onAddAppSetting,
-            onDismissRequest = onDismissTemplateDialog,
-        )
-    }
-
-    if (showWriteSecureSettingsDialog) {
-        WriteSecureSettingsDialog(onDismissRequest = onDismissWriteSecureSettingsDialog)
+    LaunchedEffect(key1 = getPinShortcutResult) {
+        if (getPinShortcutResult == GetPinShortcutResult.UnsupportedLauncher) {
+            snackbarHostState.showSnackbar(
+                message = unsupportedLauncher,
+            )
+        }
     }
 }
 

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsScreen.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsScreen.kt
@@ -71,26 +71,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.geto.broadcastreceiver.RevertSettingsBroadcastReceiver
 import com.android.geto.designsystem.icon.GetoIcons
 import com.android.geto.domain.model.AddAppSettingResult
-import com.android.geto.domain.model.AddAppSettingResult.FAILED
-import com.android.geto.domain.model.AddAppSettingResult.SUCCESS
 import com.android.geto.domain.model.AppSetting
 import com.android.geto.domain.model.AppSettingTemplate
 import com.android.geto.domain.model.AppSettingsResult
-import com.android.geto.domain.model.AppSettingsResult.DisabledAppSettings
-import com.android.geto.domain.model.AppSettingsResult.EmptyAppSettings
-import com.android.geto.domain.model.AppSettingsResult.Failure
-import com.android.geto.domain.model.AppSettingsResult.InvalidValues
-import com.android.geto.domain.model.AppSettingsResult.NoPermission
-import com.android.geto.domain.model.AppSettingsResult.Success
 import com.android.geto.domain.model.GetPinShortcutResult
 import com.android.geto.domain.model.RequestPinShortcutResult
-import com.android.geto.domain.model.RequestPinShortcutResult.SupportedLauncher
-import com.android.geto.domain.model.RequestPinShortcutResult.UnsupportedLauncher
-import com.android.geto.domain.model.RequestPinShortcutResult.UpdateFailure
-import com.android.geto.domain.model.RequestPinShortcutResult.UpdateImmutableShortcuts
-import com.android.geto.domain.model.RequestPinShortcutResult.UpdateSuccess
 import com.android.geto.domain.model.SecureSetting
 import com.android.geto.domain.model.SettingType
+import com.android.geto.domain.model.UpdatePinShortcutResult
 import com.android.geto.feature.appsettings.dialog.AppSettingDialog
 import com.android.geto.feature.appsettings.dialog.RequestPinShortcutDialog
 import com.android.geto.feature.appsettings.dialog.TemplateDialog
@@ -130,6 +118,8 @@ internal fun AppSettingsRoute(
 
     val getPinShortcutResult by viewModel.getPinShortcutResult.collectAsStateWithLifecycle()
 
+    val updatePinShortcutResult by viewModel.updatePinShortcutResult.collectAsStateWithLifecycle()
+
     AppSettingsScreen(
         modifier = modifier,
         appSettingsRouteData = appSettingsRouteData,
@@ -141,6 +131,7 @@ internal fun AppSettingsRoute(
         revertAppSettingsResult = revertAppSettingsResult,
         requestPinShortcutResult = requestPinShortcutResult,
         appSettingTemplates = appSettingTemplates,
+        updatePinShortcutResult = updatePinShortcutResult,
         onApplyAppSettings = viewModel::applyAppSettings,
         onRevertAppSettings = viewModel::revertAppSettings,
         onCheckAppSetting = viewModel::checkAppSetting,
@@ -157,6 +148,7 @@ internal fun AppSettingsRoute(
         onGetPinShortcut = viewModel::getPinShorcut,
         onResetGetPinShortcutResult = viewModel::resetGetPinShortcutResult,
         onUpdatePinShortcut = viewModel::updatePinShorcut,
+        onResetUpdatePinShortcutResult = viewModel::resetUpdatePinShortcutResult,
     )
 }
 
@@ -174,6 +166,7 @@ internal fun AppSettingsScreen(
     requestPinShortcutResult: RequestPinShortcutResult?,
     appSettingTemplates: List<AppSettingTemplate>,
     getPinShortcutResult: GetPinShortcutResult?,
+    updatePinShortcutResult: UpdatePinShortcutResult?,
     onApplyAppSettings: () -> Unit,
     onRevertAppSettings: () -> Unit,
     onCheckAppSetting: (appSetting: AppSetting) -> Unit,
@@ -197,6 +190,7 @@ internal fun AppSettingsScreen(
         shortLabel: String,
         longLabel: String,
     ) -> Unit,
+    onResetUpdatePinShortcutResult: () -> Unit,
 ) {
     var showAppSettingDialog by remember { mutableStateOf(false) }
 
@@ -215,6 +209,7 @@ internal fun AppSettingsScreen(
         revertAppSettingsResult = revertAppSettingsResult,
         requestPinShortcutResult = requestPinShortcutResult,
         getPinShortcutResult = getPinShortcutResult,
+        updatePinShortcutResult = updatePinShortcutResult,
         onResetApplyAppSettingsResult = onResetApplyAppSettingsResult,
         onResetRevertAppSettingsResult = onResetRevertAppSettingsResult,
         onResetRequestPinShortcutResult = onResetRequestPinShortcutResult,
@@ -222,6 +217,8 @@ internal fun AppSettingsScreen(
         onShowWriteSecureSettingsDialog = {
             showWriteSecureSettingsDialog = true
         },
+        onResetGetPinShortcutResult = onResetGetPinShortcutResult,
+        onResetUpdatePinShortcutResult = onResetUpdatePinShortcutResult,
     )
 
     Scaffold(
@@ -340,11 +337,14 @@ private fun AppSettingsLaunchedEffects(
     revertAppSettingsResult: AppSettingsResult?,
     requestPinShortcutResult: RequestPinShortcutResult?,
     getPinShortcutResult: GetPinShortcutResult?,
+    updatePinShortcutResult: UpdatePinShortcutResult?,
     onResetApplyAppSettingsResult: () -> Unit,
     onResetRevertAppSettingsResult: () -> Unit,
     onResetRequestPinShortcutResult: () -> Unit,
     onResetAddAppSettingResult: () -> Unit,
     onShowWriteSecureSettingsDialog: () -> Unit,
+    onResetGetPinShortcutResult: () -> Unit,
+    onResetUpdatePinShortcutResult: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -385,23 +385,31 @@ private fun AppSettingsLaunchedEffects(
 
     LaunchedEffect(key1 = applyAppSettingsResult) {
         when (applyAppSettingsResult) {
-            DisabledAppSettings -> {
+            AppSettingsResult.DisabledAppSettings -> {
                 snackbarHostState.showSnackbar(message = appSettingsDisabled)
+
+                onResetApplyAppSettingsResult()
             }
 
-            EmptyAppSettings -> {
+            AppSettingsResult.EmptyAppSettings -> {
                 snackbarHostState.showSnackbar(message = emptyAppSettingsList)
+
+                onResetApplyAppSettingsResult()
             }
 
-            Failure -> {
+            AppSettingsResult.Failure -> {
                 snackbarHostState.showSnackbar(message = applyFailure)
+
+                onResetApplyAppSettingsResult()
             }
 
-            NoPermission -> {
+            AppSettingsResult.NoPermission -> {
                 onShowWriteSecureSettingsDialog()
+
+                onResetApplyAppSettingsResult()
             }
 
-            Success -> {
+            AppSettingsResult.Success -> {
                 val notificationId = appSettingsRouteData.componentName.hashCode()
 
                 androidNotificationManagerWrapper.notify(
@@ -417,113 +425,131 @@ private fun AppSettingsLaunchedEffects(
                 )
 
                 androidLauncherAppsWrapper.startMainActivity(componentName = appSettingsRouteData.componentName)
+
+                onResetApplyAppSettingsResult()
             }
 
-            InvalidValues -> {
-                snackbarHostState.showSnackbar(
-                    message = invalidValues,
-                )
+            AppSettingsResult.InvalidValues -> {
+                snackbarHostState.showSnackbar(message = invalidValues)
+
+                onResetApplyAppSettingsResult()
             }
 
             null -> Unit
         }
-
-        onResetApplyAppSettingsResult()
     }
 
     LaunchedEffect(key1 = revertAppSettingsResult) {
         when (revertAppSettingsResult) {
-            DisabledAppSettings -> {
+            AppSettingsResult.DisabledAppSettings -> {
                 snackbarHostState.showSnackbar(message = appSettingsDisabled)
             }
 
-            EmptyAppSettings -> {
+            AppSettingsResult.EmptyAppSettings -> {
                 snackbarHostState.showSnackbar(message = emptyAppSettingsList)
+
+                onResetRevertAppSettingsResult()
             }
 
-            Failure -> {
+            AppSettingsResult.Failure -> {
                 snackbarHostState.showSnackbar(message = revertFailure)
+
+                onResetRevertAppSettingsResult()
             }
 
-            NoPermission -> {
+            AppSettingsResult.NoPermission -> {
                 onShowWriteSecureSettingsDialog()
+
+                onResetRevertAppSettingsResult()
             }
 
-            Success -> {
+            AppSettingsResult.Success -> {
                 snackbarHostState.showSnackbar(message = revertSuccess)
+
+                onResetRevertAppSettingsResult()
             }
 
-            InvalidValues -> {
-                snackbarHostState.showSnackbar(
-                    message = invalidValues,
-                )
+            AppSettingsResult.InvalidValues -> {
+                snackbarHostState.showSnackbar(message = invalidValues)
+
+                onResetRevertAppSettingsResult()
             }
 
             null -> Unit
         }
-
-        onResetRevertAppSettingsResult()
     }
 
     LaunchedEffect(key1 = requestPinShortcutResult) {
         when (requestPinShortcutResult) {
-            SupportedLauncher -> {
-                snackbarHostState.showSnackbar(
-                    message = supportedLauncher,
-                )
+            RequestPinShortcutResult.SupportedLauncher -> {
+                snackbarHostState.showSnackbar(message = supportedLauncher)
+
+                onResetRequestPinShortcutResult()
             }
 
-            UnsupportedLauncher -> {
-                snackbarHostState.showSnackbar(
-                    message = unsupportedLauncher,
-                )
-            }
+            RequestPinShortcutResult.UnsupportedLauncher -> {
+                snackbarHostState.showSnackbar(message = unsupportedLauncher)
 
-            UpdateFailure -> {
-                snackbarHostState.showSnackbar(
-                    message = shortcutUpdateFailed,
-                )
-            }
-
-            UpdateSuccess -> {
-                snackbarHostState.showSnackbar(
-                    message = shortcutUpdateSuccess,
-                )
-            }
-
-            UpdateImmutableShortcuts -> {
-                snackbarHostState.showSnackbar(
-                    message = shortcutUpdateImmutableShortcuts,
-                )
+                onResetRequestPinShortcutResult()
             }
 
             null -> Unit
         }
-
-        onResetRequestPinShortcutResult()
     }
 
     LaunchedEffect(key1 = addAppSettingResult) {
         when (addAppSettingResult) {
-            SUCCESS -> {
+            AddAppSettingResult.Success -> {
                 snackbarHostState.showSnackbar(message = appSettingAddSuccess)
+
+                onResetAddAppSettingResult()
             }
 
-            FAILED -> {
+            AddAppSettingResult.Failed -> {
                 snackbarHostState.showSnackbar(message = appSettingAddFailed)
+
+                onResetAddAppSettingResult()
             }
 
             null -> Unit
         }
-
-        onResetAddAppSettingResult()
     }
 
     LaunchedEffect(key1 = getPinShortcutResult) {
         if (getPinShortcutResult == GetPinShortcutResult.UnsupportedLauncher) {
-            snackbarHostState.showSnackbar(
-                message = unsupportedLauncher,
-            )
+            snackbarHostState.showSnackbar(message = unsupportedLauncher)
+
+            onResetGetPinShortcutResult()
+        }
+    }
+
+    LaunchedEffect(key1 = updatePinShortcutResult) {
+        when (updatePinShortcutResult) {
+            UpdatePinShortcutResult.UnsupportedLauncher -> {
+                snackbarHostState.showSnackbar(message = unsupportedLauncher)
+
+                onResetUpdatePinShortcutResult()
+            }
+
+            UpdatePinShortcutResult.UpdateSuccess -> {
+                snackbarHostState.showSnackbar(message = shortcutUpdateSuccess)
+
+                onResetUpdatePinShortcutResult()
+            }
+
+            UpdatePinShortcutResult.UpdateFailure -> {
+                snackbarHostState.showSnackbar(message = shortcutUpdateFailed)
+
+                onResetUpdatePinShortcutResult()
+            }
+
+            UpdatePinShortcutResult.UpdateImmutableShortcuts -> {
+                snackbarHostState.showSnackbar(message = shortcutUpdateImmutableShortcuts)
+
+                onResetUpdatePinShortcutResult()
+            }
+
+            null -> Unit
         }
     }
 }

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsViewModel.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsViewModel.kt
@@ -32,6 +32,7 @@ import com.android.geto.domain.model.GetPinShortcutResult
 import com.android.geto.domain.model.RequestPinShortcutResult
 import com.android.geto.domain.model.SecureSetting
 import com.android.geto.domain.model.SettingType
+import com.android.geto.domain.model.UpdatePinShortcutResult
 import com.android.geto.domain.repository.AppSettingsRepository
 import com.android.geto.domain.usecase.AddAppSettingUseCase
 import com.android.geto.domain.usecase.ApplyAppSettingsUseCase
@@ -39,6 +40,7 @@ import com.android.geto.domain.usecase.GetPinShortcutUseCase
 import com.android.geto.domain.usecase.GetSecureSettingsByNameUseCase
 import com.android.geto.domain.usecase.RequestPinShortcutUseCase
 import com.android.geto.domain.usecase.RevertAppSettingsUseCase
+import com.android.geto.domain.usecase.UpdatePinShortcutUseCase
 import com.android.geto.feature.appsettings.navigation.AppSettingsRouteData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,6 +66,7 @@ class AppSettingsViewModel @Inject constructor(
     private val getSecureSettingsByNameUseCase: GetSecureSettingsByNameUseCase,
     private val getPinShortcutUseCase: GetPinShortcutUseCase,
     private val shortcutManagerCompatWrapper: ShortcutManagerCompatWrapper,
+    private val updatePinShortcutUseCase: UpdatePinShortcutUseCase,
 ) : ViewModel() {
     private val appSettingsRouteData = savedStateHandle.toRoute<AppSettingsRouteData>()
 
@@ -112,6 +115,9 @@ class AppSettingsViewModel @Inject constructor(
 
     private val _getPinShortcutResult = MutableStateFlow<GetPinShortcutResult?>(null)
     val getPinShortcutResult = _getPinShortcutResult.asStateFlow()
+
+    private val _updatePinShortcutResult = MutableStateFlow<UpdatePinShortcutResult?>(null)
+    val updatePinShortcutResult = _updatePinShortcutResult.asStateFlow()
 
     fun applyAppSettings() {
         viewModelScope.launch {
@@ -202,13 +208,15 @@ class AppSettingsViewModel @Inject constructor(
         longLabel: String,
     ) {
         viewModelScope.launch {
-            shortcutManagerCompatWrapper.updateShortcuts(
-                componentName = componentName,
-                icon = icon,
-                id = componentName,
-                shortLabel = shortLabel,
-                longLabel = longLabel,
-            )
+            _updatePinShortcutResult.update {
+                updatePinShortcutUseCase(
+                    componentName = componentName,
+                    icon = icon,
+                    id = componentName,
+                    shortLabel = shortLabel,
+                    longLabel = longLabel,
+                )
+            }
         }
     }
 
@@ -230,5 +238,9 @@ class AppSettingsViewModel @Inject constructor(
 
     fun resetGetPinShortcutResult() {
         _getPinShortcutResult.update { null }
+    }
+
+    fun resetUpdatePinShortcutResult() {
+        _updatePinShortcutResult.update { null }
     }
 }

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsViewModel.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/AppSettingsViewModel.kt
@@ -23,16 +23,19 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.android.geto.domain.framework.AssetManagerWrapper
 import com.android.geto.domain.framework.PackageManagerWrapper
+import com.android.geto.domain.framework.ShortcutManagerCompatWrapper
 import com.android.geto.domain.model.AddAppSettingResult
 import com.android.geto.domain.model.AppSetting
 import com.android.geto.domain.model.AppSettingTemplate
 import com.android.geto.domain.model.AppSettingsResult
+import com.android.geto.domain.model.GetPinShortcutResult
 import com.android.geto.domain.model.RequestPinShortcutResult
 import com.android.geto.domain.model.SecureSetting
 import com.android.geto.domain.model.SettingType
 import com.android.geto.domain.repository.AppSettingsRepository
 import com.android.geto.domain.usecase.AddAppSettingUseCase
 import com.android.geto.domain.usecase.ApplyAppSettingsUseCase
+import com.android.geto.domain.usecase.GetPinShortcutUseCase
 import com.android.geto.domain.usecase.GetSecureSettingsByNameUseCase
 import com.android.geto.domain.usecase.RequestPinShortcutUseCase
 import com.android.geto.domain.usecase.RevertAppSettingsUseCase
@@ -59,6 +62,8 @@ class AppSettingsViewModel @Inject constructor(
     private val addAppSettingUseCase: AddAppSettingUseCase,
     private val assetManagerWrapper: AssetManagerWrapper,
     private val getSecureSettingsByNameUseCase: GetSecureSettingsByNameUseCase,
+    private val getPinShortcutUseCase: GetPinShortcutUseCase,
+    private val shortcutManagerCompatWrapper: ShortcutManagerCompatWrapper,
 ) : ViewModel() {
     private val appSettingsRouteData = savedStateHandle.toRoute<AppSettingsRouteData>()
 
@@ -96,8 +101,7 @@ class AppSettingsViewModel @Inject constructor(
                 initialValue = AppSettingsUiState.Loading,
             )
 
-    private var _appSettingTemplates =
-        MutableStateFlow<List<AppSettingTemplate>>(emptyList())
+    private val _appSettingTemplates = MutableStateFlow<List<AppSettingTemplate>>(emptyList())
     val appSettingTemplates = _appSettingTemplates.onStart {
         getAppSettingTemplates()
     }.stateIn(
@@ -105,6 +109,9 @@ class AppSettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = emptyList(),
     )
+
+    private val _getPinShortcutResult = MutableStateFlow<GetPinShortcutResult?>(null)
+    val getPinShortcutResult = _getPinShortcutResult.asStateFlow()
 
     fun applyAppSettings() {
         viewModelScope.launch {
@@ -181,6 +188,30 @@ class AppSettingsViewModel @Inject constructor(
         }
     }
 
+    fun getPinShorcut() {
+        viewModelScope.launch {
+            _getPinShortcutResult.update {
+                getPinShortcutUseCase(id = componentName)
+            }
+        }
+    }
+
+    fun updatePinShorcut(
+        icon: ByteArray?,
+        shortLabel: String,
+        longLabel: String,
+    ) {
+        viewModelScope.launch {
+            shortcutManagerCompatWrapper.updateShortcuts(
+                componentName = componentName,
+                icon = icon,
+                id = componentName,
+                shortLabel = shortLabel,
+                longLabel = longLabel,
+            )
+        }
+    }
+
     fun resetApplyAppSettingsResult() {
         _applyAppSettingsResult.update { null }
     }
@@ -195,5 +226,9 @@ class AppSettingsViewModel @Inject constructor(
 
     fun resetAddAppSettingResult() {
         _addAppSettingsResult.update { null }
+    }
+
+    fun resetGetPinShortcutResult() {
+        _getPinShortcutResult.update { null }
     }
 }

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/AppSettingDialog.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/AppSettingDialog.kt
@@ -101,17 +101,22 @@ internal fun AppSettingDialog(
     var secureSettingsExpanded by remember { mutableStateOf(false) }
 
     LaunchedEffect(key1 = Unit) {
-        snapshotFlow { key }.debounce(500).distinctUntilChanged().onEach {
-            onGetSecureSettingsByName(
-                SettingType.entries[selectedRadioOptionIndex],
-                key,
-            )
-        }.collect()
+        snapshotFlow { key }
+            .debounce(500)
+            .distinctUntilChanged()
+            .onEach {
+                onGetSecureSettingsByName(
+                    SettingType.entries[selectedRadioOptionIndex],
+                    key,
+                )
+            }.collect()
     }
 
     LaunchedEffect(key1 = Unit) {
-        snapshotFlow { selectedRadioOptionIndex }.debounce(500)
-            .distinctUntilChanged().onEach {
+        snapshotFlow { selectedRadioOptionIndex }
+            .debounce(500)
+            .distinctUntilChanged()
+            .onEach {
                 onGetSecureSettingsByName(
                     SettingType.entries[selectedRadioOptionIndex],
                     key,
@@ -129,7 +134,7 @@ internal fun AppSettingDialog(
                 .padding(10.dp),
         ) {
             Text(
-                modifier = modifier.padding(10.dp),
+                modifier = Modifier.padding(10.dp),
                 text = stringResource(R.string.add_app_setting),
                 style = MaterialTheme.typography.titleLarge,
             )
@@ -140,6 +145,8 @@ internal fun AppSettingDialog(
                     selectedRadioOptionIndex = it
                 },
             )
+
+            Spacer(modifier = Modifier.height(10.dp))
 
             AppSettingDialogTextFields(
                 key = key,
@@ -276,8 +283,6 @@ private fun AppSettingDialogTextFields(
 
     val valueOnRevertIsBlank = stringResource(id = R.string.setting_value_on_revert_is_blank)
 
-    Spacer(modifier = Modifier.height(10.dp))
-
     OutlinedTextField(
         modifier = Modifier
             .fillMaxWidth()
@@ -288,10 +293,12 @@ private fun AppSettingDialogTextFields(
             Text(text = stringResource(R.string.setting_label))
         },
         isError = showLabelError,
-        supportingText = {
-            if (showLabelError) {
+        supportingText = if (showLabelError) {
+            {
                 Text(text = labelIsBlank)
             }
+        } else {
+            null
         },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -318,10 +325,12 @@ private fun AppSettingDialogTextFields(
             Text(text = stringResource(R.string.setting_value_on_launch))
         },
         isError = showValueOnLaunchError,
-        supportingText = {
-            if (showValueOnLaunchError) {
+        supportingText = if (showValueOnLaunchError) {
+            {
                 Text(text = valueOnLaunchIsBlank)
             }
+        } else {
+            null
         },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -337,10 +346,12 @@ private fun AppSettingDialogTextFields(
             Text(text = stringResource(R.string.setting_value_on_revert))
         },
         isError = showValueOnRevertError,
-        supportingText = {
-            if (showValueOnRevertError) {
+        supportingText = if (showValueOnRevertError) {
+            {
                 Text(text = valueOnRevertIsBlank)
             }
+        } else {
+            null
         },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/ShortcutDialog.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/ShortcutDialog.kt
@@ -161,7 +161,7 @@ internal fun UpdatePinShortcutDialog(
         ) {
             Text(
                 modifier = Modifier.padding(10.dp),
-                text = stringResource(R.string.add_shortcut),
+                text = stringResource(R.string.update_shortcut),
                 style = MaterialTheme.typography.titleLarge,
             )
 

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/ShortcutDialog.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/ShortcutDialog.kt
@@ -44,14 +44,19 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.android.geto.designsystem.component.DialogContainer
+import com.android.geto.domain.model.GetoShortcutInfoCompat
 import com.android.geto.feature.appsettings.R
 
 @Composable
-internal fun ShortcutDialog(
+internal fun RequestPinShortcutDialog(
     modifier: Modifier = Modifier,
     icon: ByteArray?,
     onDismissRequest: () -> Unit,
-    onRequestPinShortcut: (ByteArray?, String, String) -> Unit,
+    onRequestPinShortcut: (
+        icon: ByteArray?,
+        shortLabel: String,
+        longLabel: String,
+    ) -> Unit,
 ) {
     var shortLabel by remember { mutableStateOf("") }
 
@@ -76,12 +81,17 @@ internal fun ShortcutDialog(
                 style = MaterialTheme.typography.titleLarge,
             )
 
-            ShortcutDialogApplicationIcon(
+            Spacer(modifier = Modifier.height(10.dp))
+
+            AsyncImage(
                 modifier = modifier
                     .size(50.dp)
                     .align(Alignment.CenterHorizontally),
-                icon = icon,
+                model = icon,
+                contentDescription = null,
             )
+
+            Spacer(modifier = Modifier.height(10.dp))
 
             ShortcutDialogTextFields(
                 longLabel = longLabel,
@@ -97,13 +107,19 @@ internal fun ShortcutDialog(
             )
 
             ShortcutDialogButtons(
+                positiveText = stringResource(id = R.string.add),
+                negativeText = stringResource(id = R.string.cancel),
                 onPositiveTextButtonClick = {
                     showShortLabelError = shortLabel.isBlank()
 
                     showLongLabelError = longLabel.isBlank()
 
                     if (!showShortLabelError && !showLongLabelError) {
-                        onRequestPinShortcut(icon, shortLabel, longLabel)
+                        onRequestPinShortcut(
+                            icon,
+                            shortLabel,
+                            longLabel,
+                        )
 
                         onDismissRequest()
                     }
@@ -115,17 +131,87 @@ internal fun ShortcutDialog(
 }
 
 @Composable
-private fun ShortcutDialogApplicationIcon(
+internal fun UpdatePinShortcutDialog(
     modifier: Modifier = Modifier,
     icon: ByteArray?,
+    getoShortcutInfoCompat: GetoShortcutInfoCompat,
+    onDismissRequest: () -> Unit,
+    onUpdatePinShortcut: (
+        icon: ByteArray?,
+        shortLabel: String,
+        longLabel: String,
+    ) -> Unit,
 ) {
-    Spacer(modifier = Modifier.height(10.dp))
+    var shortLabel by remember { mutableStateOf(getoShortcutInfoCompat.shortLabel) }
 
-    AsyncImage(
-        modifier = modifier,
-        model = icon,
-        contentDescription = null,
-    )
+    var showShortLabelError by remember { mutableStateOf(false) }
+
+    var longLabel by remember { mutableStateOf(getoShortcutInfoCompat.longLabel) }
+
+    var showLongLabelError by remember { mutableStateOf(false) }
+
+    DialogContainer(
+        modifier = modifier.verticalScroll(rememberScrollState()),
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp),
+        ) {
+            Text(
+                modifier = Modifier.padding(10.dp),
+                text = stringResource(R.string.add_shortcut),
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            AsyncImage(
+                modifier = Modifier
+                    .size(50.dp)
+                    .align(Alignment.CenterHorizontally),
+                model = icon,
+                contentDescription = null,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            ShortcutDialogTextFields(
+                longLabel = longLabel,
+                shortLabel = shortLabel,
+                showLongLabelError = showLongLabelError,
+                showShortLabelError = showShortLabelError,
+                onUpdateLongLabel = {
+                    longLabel = it
+                },
+                onUpdateShortLabel = {
+                    shortLabel = it
+                },
+            )
+
+            ShortcutDialogButtons(
+                positiveText = stringResource(id = R.string.update),
+                negativeText = stringResource(id = R.string.cancel),
+                onPositiveTextButtonClick = {
+                    showShortLabelError = shortLabel.isBlank()
+
+                    showLongLabelError = longLabel.isBlank()
+
+                    if (!showShortLabelError && !showLongLabelError) {
+                        onUpdatePinShortcut(
+                            icon,
+                            shortLabel,
+                            longLabel,
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+                onNegativeTextButtonClick = onDismissRequest,
+            )
+        }
+    }
 }
 
 @Composable
@@ -141,8 +227,6 @@ private fun ShortcutDialogTextFields(
 
     val longLabelIsBlank = stringResource(id = R.string.long_label_is_blank)
 
-    Spacer(modifier = Modifier.height(10.dp))
-
     OutlinedTextField(
         modifier = Modifier
             .fillMaxWidth()
@@ -153,15 +237,12 @@ private fun ShortcutDialogTextFields(
             Text(text = stringResource(R.string.short_label))
         },
         isError = showShortLabelError,
-        supportingText = {
-            if (showShortLabelError) {
+        supportingText = if (showShortLabelError) {
+            {
                 Text(text = shortLabelIsBlank)
-            } else {
-                Text(
-                    text = "${shortLabel.length}/10",
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
+        } else {
+            null
         },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -177,15 +258,12 @@ private fun ShortcutDialogTextFields(
             Text(text = stringResource(R.string.long_label))
         },
         isError = showLongLabelError,
-        supportingText = {
-            if (showLongLabelError) {
+        supportingText = if (showLongLabelError) {
+            {
                 Text(text = longLabelIsBlank)
-            } else {
-                Text(
-                    text = "${longLabel.length}/25",
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
+        } else {
+            null
         },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -195,6 +273,8 @@ private fun ShortcutDialogTextFields(
 @Composable
 private fun ShortcutDialogButtons(
     modifier: Modifier = Modifier,
+    positiveText: String,
+    negativeText: String,
     onPositiveTextButtonClick: () -> Unit,
     onNegativeTextButtonClick: () -> Unit,
 ) {
@@ -207,12 +287,12 @@ private fun ShortcutDialogButtons(
         TextButton(
             onClick = onNegativeTextButtonClick,
         ) {
-            Text(text = stringResource(id = R.string.cancel))
+            Text(text = negativeText)
         }
         TextButton(
             onClick = onPositiveTextButtonClick,
         ) {
-            Text(text = stringResource(id = R.string.add))
+            Text(text = positiveText)
         }
     }
 }

--- a/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/TemplateDialog.kt
+++ b/feature/app-settings/src/main/kotlin/com/android/geto/feature/appsettings/dialog/TemplateDialog.kt
@@ -59,7 +59,7 @@ internal fun TemplateDialog(
                 .padding(10.dp),
         ) {
             Text(
-                modifier = modifier.padding(10.dp),
+                modifier = Modifier.padding(10.dp),
                 text = stringResource(id = R.string.templates),
                 style = MaterialTheme.typography.titleLarge,
             )

--- a/feature/app-settings/src/main/res/values/strings.xml
+++ b/feature/app-settings/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="permission_error">Permission Error</string>
     <string name="templates">Templates</string>
     <string name="add_shortcut">Add Shortcut</string>
+    <string name="update_shortcut">Update Shortcut</string>
     <string name="short_label">Short label</string>
     <string name="long_label">Long label</string>
     <string name="short_label_is_blank">Short label is blank</string>

--- a/feature/app-settings/src/main/res/values/strings.xml
+++ b/feature/app-settings/src/main/res/values/strings.xml
@@ -59,4 +59,5 @@
     <string name="system">System</string>
     <string name="secure">Secure</string>
     <string name="global">Global</string>
+    <string name="update">Update</string>
 </resources>

--- a/feature/apps/src/main/kotlin/com/android/geto/feature/apps/AppsScreen.kt
+++ b/feature/apps/src/main/kotlin/com/android/geto/feature/apps/AppsScreen.kt
@@ -121,10 +121,12 @@ private fun Success(
 ) {
     var searchBarQuery by rememberSaveable { mutableStateOf("") }
 
-    LaunchedEffect(key1 = searchBarQuery) {
-        snapshotFlow { searchBarQuery }.debounce(500).distinctUntilChanged().onEach {
-            onSearch(it)
-        }.collect()
+    LaunchedEffect(key1 = Unit) {
+        snapshotFlow { searchBarQuery }.debounce(500)
+            .distinctUntilChanged()
+            .onEach {
+                onSearch(it)
+            }.collect()
     }
 
     Column(modifier = modifier.fillMaxWidth()) {

--- a/framework/secure-settings/src/main/kotlin/com/android/geto/framework/securesettings/DefaultSecureSettingsWrapper.kt
+++ b/framework/secure-settings/src/main/kotlin/com/android/geto/framework/securesettings/DefaultSecureSettingsWrapper.kt
@@ -112,9 +112,9 @@ internal class DefaultSecureSettingsWrapper @Inject constructor(
                     val valueIndex =
                         cursor.getColumnIndex(Settings.NameValueTable.VALUE).takeIf { it != -1 }
 
-                    val id = cursor.getLongOrNull(idIndex!!)
-                    val name = cursor.getStringOrNull(nameIndex!!)
-                    val value = cursor.getStringOrNull(valueIndex!!)
+                    val id = idIndex?.let { cursor.getLongOrNull(it) }
+                    val name = nameIndex?.let { cursor.getStringOrNull(it) }
+                    val value = valueIndex?.let { cursor.getStringOrNull(it) }
 
                     SecureSetting(
                         settingType = settingType,


### PR DESCRIPTION
This commit introduces the ability to update existing app shortcuts and refactors the dialogs for a more streamlined user experience.

- Implemented `UpdatePinShortcutDialog` for editing shortcut details.
- Renamed `ShortcutDialog` to `RequestPinShortcutDialog` for clarity.
- Added `GetPinShortcutUseCase` to retrieve shortcut information.
- Integrated shortcut update functionality into `AppSettingsViewModel`.
- Refactored `AppSettingsScreen` to handle both requesting and updating shortcuts.
- Introduced `R.string.update` for the update button text.
- Made several UI adjustments to dialogs for better presentation and usability.
- Improved error handling and input validation within dialogs.
- Added `GetPinShortcutResult` sealed interface for better result handling.
- Updated `AppSettingsViewModel` to manage `GetPinShortcutResult` state.
- Adjusted `LaunchedEffect` key in `AppsScreen` and `AppSettingDialog` for better performance.
- Refactored `ApplyAppSettingsUseCase` and `RevertAppSettingsUseCase` for improved readability by simplifying lambda expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pin-shortcut support from App Settings, including requesting pinning.
  * Added the ability to update an existing pinned shortcut (icon and labels).
  * Improved behavior when shortcut pinning isn’t supported by the launcher.
* **Bug Fixes**
  * Improved resilience when reading secure settings by avoiding crashes with missing cursor data.
* **UI Improvements**
  * Refreshed shortcut dialogs (request + update) with improved validation/error messaging and spacing.
  * Search now continues smoothly updating results as the query changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->